### PR TITLE
feat: update job completion status handling in video processing

### DIFF
--- a/cmd/job/checker/main.go
+++ b/cmd/job/checker/main.go
@@ -53,7 +53,7 @@ func main() {
 		mdcLogger.Info(fmt.Sprintf("Job %s", strings.ToLower(jobStatus)))
 		switch jobStatus {
 		case "Complete":
-			updateVideoStatus(ctx, mdcLogger, videoUsecase, jobConfig, dto.VideoStatusFinished)
+			// This status will be updated by the Video Processor Job
 			os.Exit(0)
 		case "Failed":
 			updateVideoStatus(ctx, mdcLogger, videoUsecase, jobConfig, dto.VideoStatusFailed)


### PR DESCRIPTION
This pull request makes a small change to the job status handling logic in the `cmd/job/checker/main.go` file. Specifically, it removes the call to `updateVideoStatus` when the job status is "Complete", with a comment explaining that this status will now be updated by the Video Processor Job.

* Job status handling: Removed the call to `updateVideoStatus` for "Complete" jobs in `main.go`, and added a comment clarifying that the Video Processor Job will now update this status.